### PR TITLE
Removed directories / and /tmp from being mounted as these send clam into a recursive loop

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,9 +83,7 @@ OnAccessPrevention: "true"
 OnAccessDisableDDD: "true"
 OnAccessExtraScanning: "true"
 OnAccessMountPath:
- - name: /
  - name: /home
- - name: /tmp
  - name: /var
  - name: /var/lib/docker
  - name: /var/tmp


### PR DESCRIPTION
It has been pointed out that the laptops are unusable due to CPU being taken up by clamav.

This is because scanning the /tmp directory sends it into a recursive loop.

/tmp should not be mounted by clamav.