### PR TITLE
Crossing 7071/clam av config update for periodic scans

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,6 @@ StreamMaxLength: 256M
 LogTime: "true"
 LogFileUnlock: "false"
 LogFileMaxSize: 100M
-Bytecode: "true"
 BytecodeSecurity: Paranoid
 BytecodeTimeout: 60000
 OnAccessMaxFileSize: 256M

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,7 +82,4 @@ OnAccessDisableDDD: "true"
 OnAccessExtraScanning: "true"
 OnAccessMountPath:
  - name: /home
- - name: /var
- - name: /var/lib/docker
- - name: /var/tmp
 SafeBrowsing: "true"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,6 @@ LogClean: "false"
 LogVerbose: "true"
 OfficialDatabaseOnly: "true"
 SelfCheck: 300
-Foreground: "true"
 Debug: "false"
 ScanPE: "true"
 MaxEmbeddedPE: 256M

--- a/files/clamav-daemon.service
+++ b/files/clamav-daemon.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Clam AntiVirus userspace daemon
+Documentation=man:clamd(8) man:clamd.conf(5) http://www.clamav.net/lang/en/doc/
+Requires=clamav-daemon.socket
+# Check for database existence
+ConditionPathExistsGlob=/var/lib/clamav/main.{c[vl]d,inc}
+ConditionPathExistsGlob=/var/lib/clamav/daily.{c[vl]d,inc}
+
+[Service]
+ExecStart=/usr/sbin/clamd --foreground=true
+# Reload the database
+ExecReload=/bin/kill -USR2 $MAINPID
+StandardOutput=syslog
+Nice=18
+
+[Install]
+WantedBy=multi-user.target
+Also=clamav-daemon.socket

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,12 +4,15 @@
   service:
     name: "{{ clamav_daemon }}"
     state: restarted
+  tags: usb
 
 - name: Restart Freshclam
   service:
     name: "{{ clamav_update }}"
     state: restarted
+  tags: usb
 
 - name: apparmor enforce clamd
   command: /usr/sbin/aa-enforce clamd
   notify: Restart ClamAV
+  tags: usb

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -46,10 +46,6 @@
     state: directory
     mode: 0775
 
-- name: Adjust SELinux Bytecode
-  command: setsebool -P clamd_use_jit on
-  when: ansible_distribution_version < '7'
-
 - name: Adjust SELinux RWX mapping
   command: setsebool -P antivirus_can_scan_system 1
   when: ansible_distribution_version < '7'

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Install packages
   yum:
     name: "{{ item }}"
@@ -47,3 +46,10 @@
     state: directory
     mode: 0775
 
+- name: Adjust SELinux Bytecode
+  command: setsebool -P clamd_use_jit on
+  when: ansible_distribution_version < '7'
+
+- name: Adjust SELinux RWX mapping
+  command: setsebool -P antivirus_can_scan_system 1
+  when: ansible_distribution_version < '7'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,6 +40,7 @@
     name: "{{ clamav_daemon }}"
     state: started
     enabled: yes
+  tags: usb
 
 - name: Start freshclam daemon
   service:
@@ -47,6 +48,7 @@
     state: started
     enabled: yes
   when: "{{ freshclam_enabled }}"
+  tags: usb
 
 #- shell: "/usr/local/bin/freshclam_status"
 #  register: result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,15 @@
 - name: Include tasks suitable to our OS Family
   include: "{{ ansible_os_family }}.yml"
 
+- name: Set niceness of clamav-daemon within systemd to a lower priority
+  copy:
+    src: clamav-daemon.service
+    dest: /lib/systemd/system/clamav-daemon.service
+    owner: root
+    group: root
+    mode: 0644
+  notify: Restart ClamAV
+
 - name: Replace custom clamd.conf
   template:
     dest: "{{ clamd_path }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,14 @@
   when: "{{ freshclam_enabled }}"
   tags: usb
 
+- name: Set cron job for scanning / at 12:00 on a Wednesday
+  cron:
+    name: clamdscan
+    minute: "0"
+    hour: "12"
+    dow: "4"
+    job: "systemd-cat --identifier='clamav-scan' clamdscan --multiscan --fdpass /"
+
 #- shell: "/usr/local/bin/freshclam_status"
 #  register: result
 #  until: result.stdout.find("OK") != -1

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -4,6 +4,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.box = 'hashicorp/precise32'
 
     config.vm.provision :ansible do |ansible|
+        ansible.groups = {
+            "webservers" => ["default"],
+            "dev_environment" => ["default"]
+        }
         ansible.playbook = 'playbook.yml'
         ansible.extra_vars = { ansible_ssh_user: 'vagrant', vagrant: true }
         ansible.verbose = 'vv'

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,6 +6,7 @@ update_user: clamav
 clamav_daemon: clamav-daemon
 clamav_update: clamav-freshclam
 Foreground: "true"
+Bytecode: "true"
 
 clamav_packages:
   - clamav # for manual usage

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,6 +5,7 @@ scan_user: clamav
 update_user: clamav
 clamav_daemon: clamav-daemon
 clamav_update: clamav-freshclam
+Foreground: "true"
 
 clamav_packages:
   - clamav # for manual usage

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -5,6 +5,7 @@ scan_user: clam
 update_user: clam
 clamav_daemon: clamd
 clamav_update: freshclam
+Foreground: "false"
 
 clamav_packages:
 - clamav-db

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -15,6 +15,6 @@ clamav_packages:
 # Update virus signatures database each time role runs
 clamav_fresh: true
 ClamAVLogFile: /var/log/clamav/clamav.log
-LocalSocket: /var/run/clamd.scan/clamd.ctl
+LocalSocket: /var/run/clamav/clamd.ctl
 LocalSocketGroup: clam
 DatabaseOwner: clam

--- a/vars/RedHat-6.yml
+++ b/vars/RedHat-6.yml
@@ -6,6 +6,7 @@ update_user: clam
 clamav_daemon: clamd
 clamav_update: freshclam
 Foreground: "false"
+Bytecode: "false"
 
 clamav_packages:
 - clamav-db

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,6 +6,7 @@ update_user: clamupdate
 clamav_daemon: clamd
 clamav_update: freshclam
 Foreground: "true"
+Bytecode: "true"
 
 clamav_packages:
 - clamav-server

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -5,6 +5,7 @@ scan_user: clamscan
 update_user: clamupdate
 clamav_daemon: clamd
 clamav_update: freshclam
+Foreground: "true"
 
 clamav_packages:
 - clamav-server

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -20,6 +20,6 @@ clamav_packages:
 # Update virus signatures database each time role runs
 clamav_fresh: true
 ClamAVLogFile: /var/log/clamav/clamav.log
-LocalSocket: /var/run/clamd.scan/clamd.ctl
+LocalSocket: /var/run/clamav/clamd.ctl
 LocalSocketGroup: clamscan
 DatabaseOwner: clamscan


### PR DESCRIPTION
Vagrantfile: Added ansible group so that tests can be run successfully ;
main.yml: Added cronjob for scan of root at 12pm on Wednesdays
clamav-daemon.service: Added unit file so that niceness can be defined (lower priority will mean the overhead is not felt as much if currently working)
clamd.conf: Removed /var directories from onaccess scan (they create a lot of overhead + will be scanned weekly)